### PR TITLE
Use static dataset for company table

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,5 +2,7 @@
 
 This simple dashboard displays the current Fear & Greed Index and lists the top 10 companies with the largest market capitalizations and low price-to-earnings ratios.
 
+Due to restrictions on the original public API used for the company table, the list of companies is now served from a static `companies.json` file included in this project. This avoids issues fetching data when the page is published on the web. You can replace this file with your own data if real-time results are required.
+
 ## Usage
 Open `index.html` in a web browser. The page fetches real-time data from public APIs.

--- a/companies.json
+++ b/companies.json
@@ -1,0 +1,12 @@
+[
+  {"companyName": "Berkshire Hathaway Inc.", "symbol": "BRK.B", "marketCap": 780000000000, "pe": 12.5},
+  {"companyName": "JPMorgan Chase & Co.", "symbol": "JPM", "marketCap": 470000000000, "pe": 10.4},
+  {"companyName": "Exxon Mobil Corporation", "symbol": "XOM", "marketCap": 420000000000, "pe": 13.1},
+  {"companyName": "Chevron Corporation", "symbol": "CVX", "marketCap": 300000000000, "pe": 9.8},
+  {"companyName": "Bank of America Corporation", "symbol": "BAC", "marketCap": 250000000000, "pe": 9.3},
+  {"companyName": "Toyota Motor Corporation", "symbol": "TM", "marketCap": 230000000000, "pe": 9.4},
+  {"companyName": "Pfizer Inc.", "symbol": "PFE", "marketCap": 220000000000, "pe": 9.1},
+  {"companyName": "Cisco Systems, Inc.", "symbol": "CSCO", "marketCap": 190000000000, "pe": 15.9},
+  {"companyName": "Verizon Communications Inc.", "symbol": "VZ", "marketCap": 170000000000, "pe": 7.2},
+  {"companyName": "Intel Corporation", "symbol": "INTC", "marketCap": 150000000000, "pe": 12.0}
+]

--- a/script.js
+++ b/script.js
@@ -13,7 +13,8 @@ async function fetchGreedIndex() {
 // Fetch and display top 10 companies with large market cap and low P/E
 async function fetchTopCompanies() {
   try {
-    const response = await fetch('https://financialmodelingprep.com/api/v3/stock-screener?marketCapMoreThan=100000000000&peLessThan=20&limit=100&apikey=demo');
+    // Use a static dataset to avoid external API rate limits and CORS issues
+    const response = await fetch('companies.json');
     const data = await response.json();
     const top = data.sort((a, b) => b.marketCap - a.marketCap).slice(0, 10);
 


### PR DESCRIPTION
## Summary
- avoid API failures by replacing remote stock screener call with a local `companies.json` dataset
- document new static data approach in README
- include sample top company data file

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895437a3f24832b87d9d8248c159aa2