### PR TITLE
Fix CORS issue for Fear and Greed API

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,7 +1,8 @@
 // Fetch and display the current fear and greed index
 async function fetchGreedIndex() {
   try {
-    const response = await fetch('https://api.alternative.me/fng/');
+    // Append query parameters to avoid CORS issues when deployed
+    const response = await fetch('https://api.alternative.me/fng/?limit=1&format=json&cors=true');
     const data = await response.json();
     const { value, value_classification } = data.data[0];
     document.getElementById('greed-score').textContent = `${value} (${value_classification})`;


### PR DESCRIPTION
## Summary
- append `cors=true` and other query params to Alternative.me API call to avoid CORS errors when deployed

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895450c6cac832b94448924e4c0860f