### PR TITLE
Add offline fallback data for company tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,4 @@ Company data is retrieved in real time from the [Financial Modeling Prep](https:
 
 ## Usage
 Open `index.html` in a web browser. The page fetches real-time data from public APIs.
+If the APIs are unreachable, the tables fall back to sample data located in the `data/` directory so the dashboard remains usable offline.

--- a/data/dividend_companies.json
+++ b/data/dividend_companies.json
@@ -1,0 +1,12 @@
+[
+  {"name": "Coca-Cola Co.", "symbol": "KO", "dividendYield": 3.0, "changesPercentage": 2.5},
+  {"name": "PepsiCo, Inc.", "symbol": "PEP", "dividendYield": 2.5, "changesPercentage": 1.8},
+  {"name": "Johnson & Johnson", "symbol": "JNJ", "dividendYield": 2.8, "changesPercentage": 1.2},
+  {"name": "Procter & Gamble", "symbol": "PG", "dividendYield": 2.4, "changesPercentage": 3.1},
+  {"name": "IBM", "symbol": "IBM", "dividendYield": 4.5, "changesPercentage": 2.0},
+  {"name": "McDonald's", "symbol": "MCD", "dividendYield": 2.1, "changesPercentage": 4.0},
+  {"name": "Chevron Corporation", "symbol": "CVX", "dividendYield": 3.8, "changesPercentage": 1.5},
+  {"name": "Pfizer Inc.", "symbol": "PFE", "dividendYield": 4.2, "changesPercentage": 1.7},
+  {"name": "Intel Corporation", "symbol": "INTC", "dividendYield": 3.2, "changesPercentage": 2.3},
+  {"name": "Cisco Systems", "symbol": "CSCO", "dividendYield": 3.0, "changesPercentage": 2.8}
+]

--- a/data/top_companies.json
+++ b/data/top_companies.json
@@ -1,0 +1,12 @@
+[
+  {"name": "Apple Inc.", "symbol": "AAPL", "marketCap": 2890000000000, "pe": 22.5},
+  {"name": "Microsoft Corp.", "symbol": "MSFT", "marketCap": 2400000000000, "pe": 24.0},
+  {"name": "Alphabet Inc.", "symbol": "GOOGL", "marketCap": 1700000000000, "pe": 23.2},
+  {"name": "Amazon.com Inc.", "symbol": "AMZN", "marketCap": 1600000000000, "pe": 24.9},
+  {"name": "NVIDIA Corp.", "symbol": "NVDA", "marketCap": 1200000000000, "pe": 21.1},
+  {"name": "Meta Platforms", "symbol": "META", "marketCap": 900000000000, "pe": 18.7},
+  {"name": "Tesla Inc.", "symbol": "TSLA", "marketCap": 800000000000, "pe": 19.4},
+  {"name": "Berkshire Hathaway", "symbol": "BRK.A", "marketCap": 700000000000, "pe": 20.0},
+  {"name": "Tencent Holdings", "symbol": "TCEHY", "marketCap": 500000000000, "pe": 18.5},
+  {"name": "JPMorgan Chase & Co.", "symbol": "JPM", "marketCap": 400000000000, "pe": 9.0}
+]

--- a/script.js
+++ b/script.js
@@ -17,8 +17,14 @@ async function fetchTopCompanies() {
     // Use stock-screener to retrieve a manageable list of large-cap stocks
     const url =
       'https://financialmodelingprep.com/api/v3/stock-screener?marketCapMoreThan=100000000000&limit=100&apikey=demo';
-    const response = await fetch(url);
-    const data = await response.json();
+    let data;
+    try {
+      const response = await fetch(url);
+      data = await response.json();
+    } catch (networkErr) {
+      const fallback = await fetch('data/top_companies.json');
+      data = await fallback.json();
+    }
     const top = data
       .filter(c => c.marketCap && c.pe && c.pe > 0 && c.pe < 25)
       .sort((a, b) => b.marketCap - a.marketCap)
@@ -44,8 +50,14 @@ async function fetchDividendCompanies() {
     // Retrieve dividend-paying stocks and rank by yield with positive growth
     const url =
       'https://financialmodelingprep.com/api/v3/stock-screener?dividendMoreThan=0&limit=100&apikey=demo';
-    const response = await fetch(url);
-    const data = await response.json();
+    let data;
+    try {
+      const response = await fetch(url);
+      data = await response.json();
+    } catch (networkErr) {
+      const fallback = await fetch('data/dividend_companies.json');
+      data = await fallback.json();
+    }
     const top = data
       .filter(
         c =>


### PR DESCRIPTION
## Summary
- load local `data/*.json` when external API calls fail so tables still render
- document offline sample data usage in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689554f4008c832b8228094b77b4da5c