### PR TITLE
Improve fallback for market data tables

### DIFF
--- a/script.js
+++ b/script.js
@@ -20,7 +20,13 @@ async function fetchTopCompanies() {
     let data;
     try {
       const response = await fetch(url);
+      if (!response.ok) {
+        throw new Error('API error');
+      }
       data = await response.json();
+      if (!Array.isArray(data)) {
+        throw new Error('Invalid data');
+      }
     } catch (networkErr) {
       const fallback = await fetch('data/top_companies.json');
       data = await fallback.json();
@@ -53,7 +59,13 @@ async function fetchDividendCompanies() {
     let data;
     try {
       const response = await fetch(url);
+      if (!response.ok) {
+        throw new Error('API error');
+      }
       data = await response.json();
+      if (!Array.isArray(data)) {
+        throw new Error('Invalid data');
+      }
     } catch (networkErr) {
       const fallback = await fetch('data/dividend_companies.json');
       data = await fallback.json();


### PR DESCRIPTION
## Summary
- Ensure API responses are valid before processing
- Fall back to bundled JSON when market data APIs fail

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68955697b908832bb14e7bc61ec3bcc0