### PR TITLE
Allow custom API key and clarify market cap display

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This simple dashboard displays the current Fear & Greed Index and lists the top 10 companies with the largest market capitalizations and low price-to-earnings ratios.
 
-Company data is retrieved in real time from the [Financial Modeling Prep](https://financialmodelingprep.com/) stock screener API. The included demo key is suitable for limited testing—replace the `demo` API key in `script.js` with your own key for higher usage limits.
+Company data is retrieved in real time from the [Financial Modeling Prep](https://financialmodelingprep.com/) stock screener API. The included demo key is suitable for limited testing—supply your own key via `index.html?apikey=YOUR_KEY` for up‑to‑date results and higher usage limits.
 
 ## Usage
 Open `index.html` in a web browser. The page fetches real-time data from public APIs.

--- a/data/top_companies.json
+++ b/data/top_companies.json
@@ -1,6 +1,6 @@
 [
   {"name": "Apple Inc.", "symbol": "AAPL", "marketCap": 2890000000000, "pe": 22.5},
-  {"name": "Microsoft Corp.", "symbol": "MSFT", "marketCap": 2400000000000, "pe": 24.0},
+  {"name": "Microsoft Corp.", "symbol": "MSFT", "marketCap": 4000000000000, "pe": 24.0},
   {"name": "Alphabet Inc.", "symbol": "GOOGL", "marketCap": 1700000000000, "pe": 23.2},
   {"name": "Amazon.com Inc.", "symbol": "AMZN", "marketCap": 1600000000000, "pe": 24.9},
   {"name": "NVIDIA Corp.", "symbol": "NVDA", "marketCap": 1200000000000, "pe": 21.1},

--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
       <h2>🏢 Top 10 Market Cap Companies with Low P/E</h2>
       <table>
         <thead>
-          <tr><th>Company</th><th>Ticker</th><th>Market Cap (B$)</th><th>P/E Ratio</th></tr>
+          <tr><th>Company</th><th>Ticker</th><th>Market Cap</th><th>P/E Ratio</th></tr>
         </thead>
         <tbody id="company-table">
           <!-- Filled by JS -->

--- a/script.js
+++ b/script.js
@@ -1,3 +1,14 @@
+// Retrieve API key from query string, defaulting to demo
+const apiKey = new URLSearchParams(window.location.search).get('apikey') || 'demo';
+
+function formatMarketCap(value) {
+  if (!value && value !== 0) return 'N/A';
+  if (value >= 1e12) {
+    return (value / 1e12).toFixed(2) + 'T';
+  }
+  return (value / 1e9).toFixed(2) + 'B';
+}
+
 // Fetch and display the current fear and greed index
 async function fetchGreedIndex() {
   try {
@@ -16,7 +27,7 @@ async function fetchTopCompanies() {
   try {
     // Use stock-screener to retrieve a manageable list of large-cap stocks
     const url =
-      'https://financialmodelingprep.com/api/v3/stock-screener?marketCapMoreThan=100000000000&limit=100&apikey=demo';
+      `https://financialmodelingprep.com/api/v3/stock-screener?marketCapMoreThan=100000000000&limit=100&apikey=${apiKey}`;
     let data;
     try {
       const response = await fetch(url);
@@ -39,9 +50,9 @@ async function fetchTopCompanies() {
     const table = document.getElementById('company-table');
     table.innerHTML = '';
     top.forEach(c => {
-      const marketCapB = (c.marketCap / 1e9).toFixed(2);
+      const marketCap = formatMarketCap(c.marketCap);
       const pe = c.pe ? c.pe.toFixed(2) : 'N/A';
-      const row = `<tr><td>${c.name}</td><td>${c.symbol}</td><td>${marketCapB}</td><td>${pe}</td></tr>`;
+      const row = `<tr><td>${c.name}</td><td>${c.symbol}</td><td>${marketCap}</td><td>${pe}</td></tr>`;
       table.innerHTML += row;
     });
   } catch (err) {
@@ -55,7 +66,7 @@ async function fetchDividendCompanies() {
   try {
     // Retrieve dividend-paying stocks and rank by yield with positive growth
     const url =
-      'https://financialmodelingprep.com/api/v3/stock-screener?dividendMoreThan=0&limit=100&apikey=demo';
+      `https://financialmodelingprep.com/api/v3/stock-screener?dividendMoreThan=0&limit=100&apikey=${apiKey}`;
     let data;
     try {
       const response = await fetch(url);


### PR DESCRIPTION
## Summary
- Allow supplying Financial Modeling Prep API key via `?apikey=` so dashboard can fetch fresh data
- Format market caps with trillions/billions units and clarify table heading
- Update sample data with newer Microsoft market cap and document new key usage

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a6cad32f0832baa2efdb690a82025